### PR TITLE
Fixing regex for identifying IMAP inbox folders

### DIFF
--- a/redbox/box.py
+++ b/redbox/box.py
@@ -79,7 +79,7 @@ class EmailBox:
             # box_data is in form: 
             # - '(\\HasNoChildren) "/" INBOX'
             # - '(\\HasNoChildren) "/" "Inbox"'
-            match = re.match(r'^[(](?P<flags>[^")]+)[)] "/" "?(?P<name>[^"]+)', s)
+            match = re.match(r'^[(](?P<flags>[^")]+)[)] "[/.]" "?(?P<name>[^"]+)', s)
             items = match.groupdict()
             name = items['name']
             flags = items.get('flags').split(' ')


### PR DESCRIPTION
In the `update` method in the EmailBox class, there is a regex for checking the returned mail folders from the IMAP_SSL connection. However, this regex does not catch the case where in an inbox is specified in the format `(\\HasNoChildren) "." INBOX`. This is the format returned by my IMAP server and is valid.

This commit modifies the regex to allow either the '/' or '.' to separate the flags from the folder name.

I have tested this locally and observe that it works correct:
![image](https://github.com/Mocuto/red-box/assets/5456121/b0a4d444-d546-4a90-96a7-33d1d024d599)

